### PR TITLE
Fix disappearing dialogs, warping second hand, and more

### DIFF
--- a/glade/cairo-clock.glade
+++ b/glade/cairo-clock.glade
@@ -6,7 +6,7 @@
     <child>
       <widget class="GtkImageMenuItem" id="settingsMenuItem">
         <property name="visible">True</property>
-        <property name="label" translatable="yes">Properties</property>
+        <property name="label" translatable="yes">Settings</property>
         <property name="use_underline">True</property>
         <child internal-child="image">
           <widget class="GtkImage" id="image15">
@@ -20,7 +20,7 @@
     <child>
       <widget class="GtkImageMenuItem" id="infoMenuItem">
         <property name="visible">True</property>
-        <property name="label" translatable="yes">Info</property>
+        <property name="label" translatable="yes">About</property>
         <property name="use_underline">True</property>
         <child internal-child="image">
           <widget class="GtkImage" id="image16">

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,3 @@
-[encoding: UTF-8]
 desktop/cairo-clock.desktop.in
 glade/cairo-clock.glade
 src/cairo-clock.c

--- a/po/da.po
+++ b/po/da.po
@@ -56,7 +56,7 @@ msgid "H_eight:"
 msgstr "Højde:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Information"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -76,7 +76,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Ur - Indstillinger"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Egenskaber"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/de.po
+++ b/po/de.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "Höh_e:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informationen"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Einstellungen"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Eigenschaften"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -53,8 +53,8 @@ msgid "H_eight:"
 msgstr "H_eight:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
-msgstr "Info"
+msgid "About"
+msgstr "About"
 
 #: ../glade/cairo-clock.glade.h:287
 msgid "Keep _on top"
@@ -73,8 +73,8 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Settings"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
-msgstr "Properties"
+msgid "Settings"
+msgstr "Settings"
 
 #: ../glade/cairo-clock.glade.h:293
 msgid "Quit"

--- a/po/es.po
+++ b/po/es.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "A_ltura"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Información"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "Reloj Cairo de MacSlow - Ajustes"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Propiedades"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/fi.po
+++ b/po/fi.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "Kork_eus"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Tietoja"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Asetukset"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Ominaisuudet"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,7 +54,7 @@ msgid "H_eight:"
 msgstr "H_auteur"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Info"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -74,7 +74,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Configuration"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Propriétés"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/it.po
+++ b/po/it.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "Alt_ezza"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informazioni"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Preferenze"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "ProprietÃá"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/ja.po
+++ b/po/ja.po
@@ -337,7 +337,7 @@ msgid "H_eight:"
 msgstr "高さ(_E):"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "情報"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -357,7 +357,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow の Cairo 時計 - 設定"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "設定"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/nl.po
+++ b/po/nl.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "Hoogt_e"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informatie"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Instellingen"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Eigenschappen"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/nn.po
+++ b/po/nn.po
@@ -54,7 +54,7 @@ msgid "H_eight:"
 msgstr "Høgd_e:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informasjon"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -74,7 +74,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Innstillingar"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Eigenskaper"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/pl.po
+++ b/po/pl.po
@@ -56,7 +56,7 @@ msgid "H_eight:"
 msgstr "Wysokość"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informacje"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -76,7 +76,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "Ustawienia zegara Cairo MacSlowa"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Preferencje"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "_Altura:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informação"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Configurações"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Propriedades"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/ru.po
+++ b/po/ru.po
@@ -55,7 +55,7 @@ msgid "H_eight:"
 msgstr "_Высота:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Инфо"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -75,7 +75,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Настройки"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Свойства"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/sl.po
+++ b/po/sl.po
@@ -56,7 +56,7 @@ msgid "H_eight:"
 msgstr "_Višina:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Informacije"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -76,7 +76,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow Cairo Ura - Nastavitve"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Lastnosti"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/sv.po
+++ b/po/sv.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "Höjd:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Information"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Inställningar"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Egenskaper"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/tr.po
+++ b/po/tr.po
@@ -54,7 +54,7 @@ msgid "H_eight:"
 msgstr "Yüks_eklik:"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "Bilgi"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -74,7 +74,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - Ayarlar"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "Özellikler"
 
 #: ../glade/cairo-clock.glade.h:293

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -53,7 +53,7 @@ msgid "H_eight:"
 msgstr "H_eight"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "信息"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -73,7 +73,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow 的 Cairo 时钟 - 设置"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "属性"
 
 #: ../glade/cairo-clock.glade.h:293
@@ -265,4 +265,3 @@ msgstr "不能加载 \"%s\"！\n"
 #, c-format
 msgid "Ups, error while trying to save the preferences!\n"
 msgstr "汗，试图保存设置时出错！\n"
-

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -341,7 +341,7 @@ msgid "H_eight:"
 msgstr "高度(_e)"
 
 #: ../glade/cairo-clock.glade.h:286
-msgid "Info"
+msgid "About"
 msgstr "資訊"
 
 #: ../glade/cairo-clock.glade.h:287
@@ -361,7 +361,7 @@ msgid "MacSlow's Cairo-Clock - Settings"
 msgstr "MacSlow's Cairo-Clock - 設定"
 
 #: ../glade/cairo-clock.glade.h:292
-msgid "Properties"
+msgid "Settings"
 msgstr "屬性"
 
 #: ../glade/cairo-clock.glade.h:293


### PR DESCRIPTION
Hi @MacSlow!

## Background

My physical analog clock stopped working today, so I looked for one in GNOME Shell and found this. Thanks! It helped me complete my physician-assigned forearm stretching exercises as I had become accustomed.

I tried turning on the "Show date" option, and it used the wrong format for my locale (DD/MM instead of MM/DD):

![image](https://user-images.githubusercontent.com/1559108/140677152-e6d7d8ee-494d-49dc-820b-3e4e37f67cb7.png)

So I resolved to try to fix that, but when I compiled it, I saw that it was already fixed:

![image](https://user-images.githubusercontent.com/1559108/140678575-f8182ed0-7d4e-4865-926e-91f034a0df6d.png)

However, by then I had noticed some other quirks. Here's my attempt to fix them.

## Problems

- Compilation fails when `[encoding: UTF-8]` is copied into `po/Makefile` and evaluated as a target dependendency
- The second hand jumps around at startup and when you change the smoothness setting
- If you set a custom startup size (I was testing with 400x400), sometimes the background image is the wrong size at startup (looked like 200x200), but the hands are normal
  ![image](https://user-images.githubusercontent.com/1559108/140678756-0c0752e0-eac4-4b04-b639-8624e5326f14.png)
- If the date displays in MM/DD/YYYY format, it's too large and overwrites the hour numerals (see second screenshot above)
- "Properties" and "Info" are unusual names for those options; most GNOME apps seems to use "Settings" and "About" for these concepts
- If you open the Properties or Info window and then close it with your window manager's close button, you can't open it again unless you restart
- If you enable the "Keep on top" option, only the main window is affected, but you probably still want to finish using the Properties or Info windows if you've opened them and accidentally clicked another window

## Changes

- Now the project compiles (that line is removed from `po/POTFILES.in`)
- Now the second hand is steady and always in the right place (frame is calculated from microseconds instead of starting at 0 and incrementing every call)
- Now the background image will be resized if it's the wrong size
- Now the date is slightly smaller and lower
  ![image](https://user-images.githubusercontent.com/1559108/140677430-1fe03e33-acee-4905-836a-517b5f97d513.png)
- Now the menu says "Settings" and "About" in the default locale and `en_GB` (all others have the `msgid` values updated but the localized strings left as-is)
- Now you can re-open the Properties (Settings) and Info (About) windows after closing them with the window manager's close button
- Now the Properties (Settings) and Info (About) windows will also stay on top if you enable "Keep on top"

Cheers!